### PR TITLE
Add response headers into api response

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mlp-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "27.0.0",
-    "@gojek/mlp-ui": "1.0.0",
+    "@gojek/mlp-ui": "1.0.1",
     "@reach/router": "1.3.3",
     "@sentry/browser": "5.15.5",
     "moment": "2.25.3",

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/ui/packages/lib/src/hooks/useApi.js
+++ b/ui/packages/lib/src/hooks/useApi.js
@@ -21,7 +21,8 @@ const zeroState = data => ({
   data: data,
   isLoading: false,
   isLoaded: false,
-  error: null
+  error: null,
+  headers: null
 });
 
 const dataFetchReducer = (state, action) => {
@@ -33,14 +34,16 @@ const dataFetchReducer = (state, action) => {
         ...state,
         isLoading: true,
         isLoaded: false,
-        error: null
+        error: null,
+        headers: null
       };
     case "FETCH_SUCCESS":
       return {
         ...state,
         isLoading: false,
         isLoaded: true,
-        data: action.payload
+        data: action.payload,
+        headers: action.headers
       };
     case "FETCH_FAILURE":
       return {
@@ -112,7 +115,12 @@ export const useApi = (
           )
       )
         .then(result => {
-          if (!didCancel) dispatch({ type: "FETCH_SUCCESS", payload: result });
+          if (!didCancel)
+            dispatch({
+              type: "FETCH_SUCCESS",
+              payload: result.body,
+              headers: result.headers
+            });
         })
         .catch(error => {
           if (!didCancel) dispatch({ type: "FETCH_FAILURE", error: error });

--- a/ui/packages/lib/src/utils/fetchJson.js
+++ b/ui/packages/lib/src/utils/fetchJson.js
@@ -49,7 +49,15 @@ const fetchData = async (url, authCtx, options) => {
 
 export default async (url, authCtx, options = {}) => {
   return fetchData(url, authCtx, options)
-    .then(parseJson)
+    .then(response =>
+      parseJson(response).then(result => {
+        var headers = {};
+        for (var pair of response.headers.entries()) {
+          headers[pair[0]] = pair[1];
+        }
+        return { body: result, headers: headers };
+      })
+    )
     .then(result => {
       if (options.addToast) {
         addToast({


### PR DESCRIPTION
Currently we use `useApi` to do any API call, this method only returning json body on the response. Some API needs to access the response headers. Hence we need to modify `useApi` function to return response headers also