### PR TITLE
Add new resource using project name

### DIFF
--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -152,15 +152,17 @@ func (service *projectsService) upsertAdministratorsRole(project *models.Project
 func (service *projectsService) upsertAdministratorsPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
+	nameResource := fmt.Sprintf(ProjectResources, project.Name)
 	policyName := fmt.Sprintf("%s-administrators-policy", project.Name)
-	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources}, []string{enforcer.ActionAll})
+	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionAll})
 	return err
 }
 
 func (service *projectsService) upsertReadersPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
+	nameResource := fmt.Sprintf(ProjectResources, project.Name)
 	policyName := fmt.Sprintf("%s-readers-policy", project.Name)
-	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources}, []string{enforcer.ActionRead})
+	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionRead})
 	return err
 }

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -152,7 +152,7 @@ func (service *projectsService) upsertAdministratorsRole(project *models.Project
 func (service *projectsService) upsertAdministratorsPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
-	nameResource := fmt.Sprintf(ProjectResources, project.Name)
+	nameResource := fmt.Sprintf(ProjectSubResources, project.Name)
 	policyName := fmt.Sprintf("%s-administrators-policy", project.Name)
 	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionAll})
 	return err
@@ -161,7 +161,7 @@ func (service *projectsService) upsertAdministratorsPolicy(role string, project 
 func (service *projectsService) upsertReadersPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
-	nameResource := fmt.Sprintf(ProjectResources, project.Name)
+	nameResource := fmt.Sprintf(ProjectSubResources, project.Name)
 	policyName := fmt.Sprintf("%s-readers-policy", project.Name)
 	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionRead})
 	return err

--- a/api/service/projects_service.go
+++ b/api/service/projects_service.go
@@ -152,7 +152,7 @@ func (service *projectsService) upsertAdministratorsRole(project *models.Project
 func (service *projectsService) upsertAdministratorsPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
-	nameResource := fmt.Sprintf(ProjectSubResources, project.Name)
+	nameResource := fmt.Sprintf(ProjectResources, project.Name)
 	policyName := fmt.Sprintf("%s-administrators-policy", project.Name)
 	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionAll})
 	return err
@@ -161,7 +161,7 @@ func (service *projectsService) upsertAdministratorsPolicy(role string, project 
 func (service *projectsService) upsertReadersPolicy(role string, project *models.Project) error {
 	subResources := fmt.Sprintf(ProjectSubResources, project.Id)
 	resource := fmt.Sprintf(ProjectResources, project.Id)
-	nameResource := fmt.Sprintf(ProjectSubResources, project.Name)
+	nameResource := fmt.Sprintf(ProjectResources, project.Name)
 	policyName := fmt.Sprintf("%s-readers-policy", project.Name)
 	_, err := service.authEnforcer.UpsertPolicy(policyName, []string{role}, []string{}, []string{resource, subResources, nameResource}, []string{enforcer.ActionRead})
 	return err

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -83,7 +83,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 
 			projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 			projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
-			projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
+			projectNameResource := fmt.Sprintf(ProjectSubResources, tt.arg.Name)
 
 			authEnforcer := &enforcerMock.Enforcer{}
 			if tt.authEnabled {
@@ -180,7 +180,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 				projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 				projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
-				projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
+				projectNameResource := fmt.Sprintf(ProjectSubResources, tt.arg.Name)
 
 				authEnforcer.On("UpsertRole", fmt.Sprintf("%s-administrators", tt.arg.Name), []string(tt.arg.Administrators)).
 					Return(&types.Role{

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -83,6 +83,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 
 			projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 			projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
+			projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
 
 			authEnforcer := &enforcerMock.Enforcer{}
 			if tt.authEnabled {
@@ -96,18 +97,18 @@ func TestProjectsService_CreateProject(t *testing.T) {
 						ID:      "reader-role",
 						Members: tt.arg.Readers,
 					}, nil)
-				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-administrators-policy", tt.arg.Name), []string{"admin-role"}, []string{}, []string{projectResource, projectSubResource}, []string{enforcer.ActionAll}).
+				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-administrators-policy", tt.arg.Name), []string{"admin-role"}, []string{}, []string{projectResource, projectSubResource, projectNameResource}, []string{enforcer.ActionAll}).
 					Return(&types.Policy{
 						ID:        "admin-policy",
 						Subjects:  []string{"admin-role"},
-						Resources: []string{projectResource, projectSubResource},
+						Resources: []string{projectResource, projectSubResource, projectNameResource},
 						Actions:   []string{enforcer.ActionAll},
 					}, nil)
-				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-readers-policy", tt.arg.Name), []string{"reader-role"}, []string{}, []string{projectResource, projectSubResource}, []string{enforcer.ActionRead}).
+				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-readers-policy", tt.arg.Name), []string{"reader-role"}, []string{}, []string{projectResource, projectSubResource, projectNameResource}, []string{enforcer.ActionRead}).
 					Return(&types.Policy{
 						ID:        "reader-policy",
 						Subjects:  []string{"readers-role"},
-						Resources: []string{projectResource, projectSubResource},
+						Resources: []string{projectResource, projectSubResource, projectNameResource},
 						Actions:   []string{enforcer.ActionRead},
 					}, nil)
 			}
@@ -179,6 +180,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 				projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 				projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
+				projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
 
 				authEnforcer.On("UpsertRole", fmt.Sprintf("%s-administrators", tt.arg.Name), []string(tt.arg.Administrators)).
 					Return(&types.Role{
@@ -190,18 +192,18 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 						ID:      "reader-role",
 						Members: tt.arg.Readers,
 					}, nil)
-				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-administrators-policy", tt.arg.Name), []string{"admin-role"}, []string{}, []string{projectResource, projectSubResource}, []string{enforcer.ActionAll}).
+				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-administrators-policy", tt.arg.Name), []string{"admin-role"}, []string{}, []string{projectResource, projectSubResource, projectNameResource}, []string{enforcer.ActionAll}).
 					Return(&types.Policy{
 						ID:        "admin-policy",
 						Subjects:  []string{"admin-role"},
-						Resources: []string{projectResource, projectSubResource},
+						Resources: []string{projectResource, projectSubResource, projectNameResource},
 						Actions:   []string{enforcer.ActionAll},
 					}, nil)
-				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-readers-policy", tt.arg.Name), []string{"reader-role"}, []string{}, []string{projectResource, projectSubResource}, []string{enforcer.ActionRead}).
+				authEnforcer.On("UpsertPolicy", fmt.Sprintf("%s-readers-policy", tt.arg.Name), []string{"reader-role"}, []string{}, []string{projectResource, projectSubResource, projectNameResource}, []string{enforcer.ActionRead}).
 					Return(&types.Policy{
 						ID:        "reader-policy",
 						Subjects:  []string{"readers-role"},
-						Resources: []string{projectResource, projectSubResource},
+						Resources: []string{projectResource, projectSubResource, projectNameResource},
 						Actions:   []string{enforcer.ActionRead},
 					}, nil)
 			}

--- a/api/service/projects_service_test.go
+++ b/api/service/projects_service_test.go
@@ -83,7 +83,7 @@ func TestProjectsService_CreateProject(t *testing.T) {
 
 			projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 			projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
-			projectNameResource := fmt.Sprintf(ProjectSubResources, tt.arg.Name)
+			projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
 
 			authEnforcer := &enforcerMock.Enforcer{}
 			if tt.authEnabled {
@@ -180,7 +180,7 @@ func TestProjectsService_UpdateProject(t *testing.T) {
 
 				projectResource := fmt.Sprintf(ProjectResources, tt.arg.Id)
 				projectSubResource := fmt.Sprintf(ProjectSubResources, tt.arg.Id)
-				projectNameResource := fmt.Sprintf(ProjectSubResources, tt.arg.Name)
+				projectNameResource := fmt.Sprintf(ProjectResources, tt.arg.Name)
 
 				authEnforcer.On("UpsertRole", fmt.Sprintf("%s-administrators", tt.arg.Name), []string(tt.arg.Administrators)).
 					Return(&types.Role{


### PR DESCRIPTION
Currently, Keto policy expects projects in the form of `resources:mlp:projects:<project_id>` but Feast expects projects in the form of `resources:mlp:projects:<project_name>`. 

Related Feast code can be found [here](https://github.com/feast-dev/feast-java/blob/master/common/src/main/java/feast/common/auth/providers/keto/KetoAuthorizationProvider.java#L144).

This PR simply adds an additional resource in the `upsert` methods to overcome this disparity.