### PR TITLE
Fix collapsible nav props

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mlp-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
     "@elastic/datemath": "5.0.3",
     "@elastic/eui": "31.10.0",
-    "@gojek/mlp-ui": "1.4.0",
+    "@gojek/mlp-ui": "1.4.1",
     "@reach/router": "1.3.3",
     "@sentry/browser": "5.15.5",
     "moment": "2.25.3",

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
+++ b/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
@@ -9,8 +9,7 @@ import {
   EuiHeaderSectionItemButton,
   EuiIcon,
   EuiFlexItem,
-  EuiSpacer,
-  EuiShowFor
+  EuiSpacer
 } from "@elastic/eui";
 import ApplicationsContext from "../../providers/application/context";
 import { CurrentProjectContext } from "../../providers/project";
@@ -68,7 +67,7 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
         <EuiFlexItem grow={true}>
           {mlpLinks.length > 0 && (
             <EuiCollapsibleNavGroup
-              isCollapsible={false}
+              isCollapsible={true}
               initialIsOpen={appExpanded}
               onToggle={toggleAppExpanded}
               iconType="apps"
@@ -88,7 +87,7 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
             <EuiCollapsibleNavGroup
               title="Learn"
               iconType="training"
-              isCollapsible={false}
+              isCollapsible={true}
               initialIsOpen={docsExpanded}
               onToggle={toggleDocsExpanded}>
               <EuiListGroup
@@ -120,23 +119,21 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
         <EuiHorizontalRule margin="none" />
 
         <EuiFlexItem grow={false}>
-          <EuiShowFor sizes={["l", "xl"]}>
-            <EuiCollapsibleNavGroup>
-              <EuiListGroupItem
-                size="s"
-                color="subdued"
-                label={`${navIsDocked ? "Undock" : "Dock"} navigation`}
-                onClick={() => {
-                  setNavIsDocked(!navIsDocked);
-                  localStorage.setItem(
-                    'mlp-navIsDocked',
-                    JSON.stringify(!navIsDocked)
-                  );
-                }}
-                iconType={navIsDocked ? "lock" : "lockOpen"}
-              />
-            </EuiCollapsibleNavGroup>
-          </EuiShowFor>
+          <EuiCollapsibleNavGroup>
+            <EuiListGroupItem
+              size="s"
+              color="subdued"
+              label={`${navIsDocked ? "Undock" : "Dock"} navigation`}
+              onClick={() => {
+                setNavIsDocked(!navIsDocked);
+                localStorage.setItem(
+                  'mlp-navIsDocked',
+                  JSON.stringify(!navIsDocked)
+                );
+              }}
+              iconType={navIsDocked ? "lock" : "lockOpen"}
+            />
+          </EuiCollapsibleNavGroup>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiCollapsibleNav>


### PR DESCRIPTION
For nav to be collapsible, `isCollapsible=true` is required as described in the [documentation](https://elastic.github.io/eui/#/navigation/collapsible-nav#collapsible-nav-group).

![image](https://user-images.githubusercontent.com/25025366/116505044-70042480-a8ec-11eb-84df-a9b791fb0151.png)
