### PR TITLE
Set rollingUpdate's maxSurge to 2 and maxUnavailable to 0

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -16,6 +16,9 @@ spec:
       release: {{ .Release.Name }}
   strategy:
     type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Currently, as we don't specify the `rollingUpdate`'s options, we are using the default value for both `maxSurge` and `maxUnavailable`, which is 25% for both of them. By setting `maxUnavailable` to 0, we can achieve zero downtime for MLP deployment.