### PR TITLE
Fix link to Deploy Model

### DIFF
--- a/ui/packages/app/src/pages/project/components/Resources.js
+++ b/ui/packages/app/src/pages/project/components/Resources.js
@@ -49,7 +49,7 @@ export const Resources = ({
       size="s">
       Create FeatureTable
     </EuiContextMenuItem>,
-    <EuiContextMenuItem href={config.MERLIN_UI_HOMEPAGE} key="model" size="s">
+    <EuiContextMenuItem href={`${config.MERLIN_UI_HOMEPAGE}/projects/${project.id}`} key="model" size="s">
       Deploy model
     </EuiContextMenuItem>,
     <EuiContextMenuItem


### PR DESCRIPTION
Currently, the link goes to `${MERLIN_HOST}/merlin` instead of `${MERLIN_HOST}/merlin/projects/${PROJECT_ID}`. This PR fixes that.