### PR TITLE
Add custom model type mapping

### DIFF
--- a/ui/packages/app/src/services/merlin/Model.js
+++ b/ui/packages/app/src/services/merlin/Model.js
@@ -4,7 +4,8 @@ export const MODEL_TYPE_NAME_MAP = {
   sklearn: "SKLearn",
   tensorflow: "Tensorflow",
   xgboost: "XGBoost",
-
+  
   pyfunc: "Pyfunc",
-  pyfunc_v2: "Pyfunc"
+  pyfunc_v2: "Pyfunc",
+  custom: "Custom"
 };


### PR DESCRIPTION
Before adding mapping for custom model, `resources` panel only show number without model type.

<img width="381" alt="Screen Shot 2021-06-23 at 10 21 20" src="https://user-images.githubusercontent.com/2369255/123030284-c4b7ad80-d40c-11eb-8cad-8f2e21bade41.png">

After:
<img width="465" alt="Screen Shot 2021-06-23 at 10 22 45" src="https://user-images.githubusercontent.com/2369255/123030402-f6c90f80-d40c-11eb-90e8-5687b9255634.png">
