### PR TITLE
Bump newrelic version

### DIFF
--- a/api/pkg/instrumentation/newrelic/noop.go
+++ b/api/pkg/instrumentation/newrelic/noop.go
@@ -40,6 +40,10 @@ type NoopTx struct {
 	w http.ResponseWriter
 }
 
+func (nt *NoopTx) IsSampled() bool {
+	return false
+}
+
 // End implements newrelic.Transaction interface.
 func (nt *NoopTx) End() error {
 	return nil

--- a/api/pkg/instrumentation/newrelic/noop_test.go
+++ b/api/pkg/instrumentation/newrelic/noop_test.go
@@ -39,4 +39,5 @@ func TestNoopTx(t *testing.T) {
 	nt.WriteHeader(0)
 	nt.GetTraceMetadata()
 	nt.GetLinkingMetadata()
+	nt.IsSampled()
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/leodido/go-urn v1.2.0 // indirect
 	github.com/lib/pq v1.3.0
-	github.com/newrelic/go-agent v2.13.0+incompatible
+	github.com/newrelic/go-agent v3.9.0+incompatible
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/ory/keto-client-go v0.4.3-alpha.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/neo4j-drivers/gobolt v1.7.4/go.mod h1:O9AUbip4Dgre+CD3p40dnMD4a4r52QBIfblg5k7CTbE=
 github.com/neo4j/neo4j-go-driver v1.7.4/go.mod h1:aPO0vVr+WnhEJne+FgFjfsjzAnssPFLucHgGZ76Zb/U=
-github.com/newrelic/go-agent v2.13.0+incompatible h1:Dl6m75MHAzfB0kicv9GiLxzQatRjTLUAdrnYyoT8s4M=
-github.com/newrelic/go-agent v2.13.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
+github.com/newrelic/go-agent v3.9.0+incompatible h1:W2Zummx9jNATZVX6QVjYksX1TwxJGf4E6x1Wf3CG/jY=
+github.com/newrelic/go-agent v3.9.0+incompatible/go.mod h1:a8Fv1b/fYhFSReoTU6HDkTYIMZeSVNffmoS726Y0LzQ=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
This PR updates current noop implementation which does not support updated NewRelic version's `newrelic.Transaction` interface. Existing v2 NewRelic agent has also been deprecated.