### PR TITLE
Add sub-sections into NavDrawer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ build-docker:
 # Run recipes
 # ============================================================
 .PHONY: run
-run:
+run: build-api local-db
 	@echo "> Running application ..."
 	@./bin/${BIN_NAME}
 

--- a/api/models/application.go
+++ b/api/models/application.go
@@ -1,12 +1,52 @@
 package models
 
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+)
+
 type Application struct {
-	Id          Id     `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Href        string `json:"href"`
-	IconName    string `json:"icon" gorm:"column:icon"`
-	UseProjects bool   `json:"use_projects"`
-	IsInBeta    bool   `json:"is_in_beta"`
-	IsDisabled  bool   `json:"is_disabled"`
+	Id          Id                 `json:"id"`
+	Name        string             `json:"name"`
+	Description string             `json:"description"`
+	Href        string             `json:"href"`
+	IconName    string             `json:"icon" gorm:"column:icon"`
+	UseProjects bool               `json:"use_projects"`
+	IsInBeta    bool               `json:"is_in_beta"`
+	IsDisabled  bool               `json:"is_disabled"`
+	Config      *ApplicationConfig `json:"config"`
+}
+
+type ApplicationConfig struct {
+	Sections []ApplicationSection `json:"sections"`
+}
+
+func (c ApplicationConfig) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func (c *ApplicationConfig) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+	return json.Unmarshal(b, &c)
+}
+
+type ApplicationSection struct {
+	Name string `json:"name"`
+	Href string `json:"href"`
+}
+
+func (c ApplicationSection) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func (c *ApplicationSection) Scan(value interface{}) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
+	}
+	return json.Unmarshal(b, &c)
 }

--- a/db-migrations/7_application_config.down.sql
+++ b/db-migrations/7_application_config.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE applications DROP COLUMN config;

--- a/db-migrations/7_application_config.up.sql
+++ b/db-migrations/7_application_config.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE applications ADD config jsonb;
+
+UPDATE applications
+SET config = '{"sections": [{"name": "Routers", "href": "/routers"}, {"name": "Ensembling Jobs", "href": "/jobs"}]}'
+WHERE name = 'Turing';

--- a/db-migrations/7_application_config.up.sql
+++ b/db-migrations/7_application_config.up.sql
@@ -1,5 +1,5 @@
 ALTER TABLE applications ADD config jsonb;
 
 UPDATE applications
-SET config = '{"sections": [{"name": "Routers", "href": "/routers"}, {"name": "Ensembling Jobs", "href": "/jobs"}]}'
+SET config = '{"sections": [{"name": "Routers", "href": "/routers"}, {"name": "Ensemblers", "href": "/ensemblers"}, {"name": "Ensembling Jobs", "href": "/jobs"}]}'
 WHERE name = 'Turing';

--- a/ui/packages/app/src/PrivateLayout.js
+++ b/ui/packages/app/src/PrivateLayout.js
@@ -16,9 +16,7 @@ export const PrivateLayout = Component => {
         <CurrentProjectContextProvider {...props}>
           <Header
             appIcon="graphApp"
-            onProjectSelect={projectId =>
-              navigate(`/projects/${projectId}`)
-            }
+            onProjectSelect={projectId => navigate(`/projects/${projectId}`)}
             docLinks={config.DOC_LINKS}
           />
           <div className="main-component-layout">

--- a/ui/packages/app/src/config.js
+++ b/ui/packages/app/src/config.js
@@ -15,9 +15,16 @@ const config = {
   TEAMS: (getEnv("REACT_APP_TEAMS") || []).map(team => team.trim()),
   STREAMS: (getEnv("REACT_APP_STREAMS") || []).map(stream => stream.trim()),
   DOC_LINKS: getEnv("REACT_APP_DOC_LINKS") || [
-    {"href":"https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md","label":"Merlin User Guide"},
-    {"href":"https://github.com/gojek/turing","label":"Turing User Guide"},
-    {"href":"https://docs.feast.dev/user-guide/overview","label":"Feast User Guide"},
+    {
+      href:
+        "https://github.com/gojek/merlin/blob/main/docs/getting-started/README.md",
+      label: "Merlin User Guide"
+    },
+    { href: "https://github.com/gojek/turing", label: "Turing User Guide" },
+    {
+      href: "https://docs.feast.dev/user-guide/overview",
+      label: "Feast User Guide"
+    }
   ],
 
   FEAST_CORE_API: getEnv("REACT_APP_FEAST_CORE_API"),
@@ -28,7 +35,7 @@ const config = {
   FEAST_UI_HOMEPAGE: getEnv("REACT_APP_FEAST_UI_HOMEPAGE") || "/feast",
   KUBEFLOW_UI_HOMEPAGE: getEnv("REACT_APP_KUBEFLOW_UI_HOMEPAGE"),
   MERLIN_UI_HOMEPAGE: getEnv("REACT_APP_MERLIN_UI_HOMEPAGE") || "/merlin",
-  TURING_UI_HOMEPAGE: getEnv("REACT_APP_TURING_UI_HOMEPAGE") || "/turing",
+  TURING_UI_HOMEPAGE: getEnv("REACT_APP_TURING_UI_HOMEPAGE") || "/turing"
 };
 
 export default {

--- a/ui/packages/app/src/pages/project/Project.js
+++ b/ui/packages/app/src/pages/project/Project.js
@@ -59,9 +59,18 @@ const Project = () => {
 
   useEffect(() => {
     if (project) {
-      fetchEntities({ body: JSON.stringify({ "filter": { "project": project.name } }) });
-      fetchFeatureTables({ body: JSON.stringify({ "filter": { "project": project.name } }) });
-      fetchFeastIngestionJobs({ body: JSON.stringify({ "include_terminated":true, "project": project.name.replace(/-/g, "_") }) });
+      fetchEntities({
+        body: JSON.stringify({ filter: { project: project.name } })
+      });
+      fetchFeatureTables({
+        body: JSON.stringify({ filter: { project: project.name } })
+      });
+      fetchFeastIngestionJobs({
+        body: JSON.stringify({
+          include_terminated: true,
+          project: project.name.replace(/-/g, "_")
+        })
+      });
       fetchModels();
       fetchRouters();
     }
@@ -118,7 +127,10 @@ const Project = () => {
 
             <EuiFlexGroup>
               <EuiFlexItem grow={5}>
-                <ComingSoonPanel title="Health Monitoring" iconType="monitoringApp" />
+                <ComingSoonPanel
+                  title="Health Monitoring"
+                  iconType="monitoringApp"
+                />
               </EuiFlexItem>
               <EuiFlexItem grow={4}>
                 <ComingSoonPanel title="Error Summary" iconType="bug" />

--- a/ui/packages/app/src/pages/project/components/ComingSoonPanel.js
+++ b/ui/packages/app/src/pages/project/components/ComingSoonPanel.js
@@ -1,8 +1,5 @@
 import React from "react";
-import {
-  EuiCard,
-  EuiIcon,
-} from "@elastic/eui";
+import { EuiCard, EuiIcon } from "@elastic/eui";
 
 export const ComingSoonPanel = ({ title, iconType }) => {
   return (

--- a/ui/packages/app/src/pages/project/components/FeastJobsTable.js
+++ b/ui/packages/app/src/pages/project/components/FeastJobsTable.js
@@ -62,8 +62,11 @@ export const FeastJobsTable = ({ project, feastIngestionJobs }) => {
 
   const cellProps = item => ({
     style: { cursor: "pointer" },
-    onClick: () => window.location.href = `/feast/projects/${project.id}/jobs/${item.type}`,
+    onClick: () =>
+      (window.location.href = `/feast/projects/${project.id}/jobs/${item.type}`)
   });
 
-  return <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />;
+  return (
+    <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />
+  );
 };

--- a/ui/packages/app/src/pages/project/components/Instances.js
+++ b/ui/packages/app/src/pages/project/components/Instances.js
@@ -53,5 +53,7 @@ export const Instances = ({ project, feastIngestionJobs, models, routers }) => {
     }
   ];
 
-  return <Panel title="Instances" items={items} type="row" iconType="compute" />;
+  return (
+    <Panel title="Instances" items={items} type="row" iconType="compute" />
+  );
 };

--- a/ui/packages/app/src/pages/project/components/MerlinDeployments.js
+++ b/ui/packages/app/src/pages/project/components/MerlinDeployments.js
@@ -55,7 +55,9 @@ export const MerlinDeployments = ({ project, models }) => {
                 <EuiText size="s">{totalServing} active serving</EuiText>
               </>
             ),
-            onClick: () => { window.location.href = `/merlin/projects/${project.id}/models/${model.id}`; },
+            onClick: () => {
+              window.location.href = `/merlin/projects/${project.id}/models/${model.id}`;
+            },
             size: "s"
           };
         });

--- a/ui/packages/app/src/pages/project/components/MerlinDeploymentsTable.js
+++ b/ui/packages/app/src/pages/project/components/MerlinDeploymentsTable.js
@@ -28,7 +28,7 @@ export const MerlinDeploymentsTable = ({ project, models }) => {
                 environment_name: endpoint.environment_name,
                 endpoint: endpoint.url,
                 version_id: destination.version_endpoint.version_id,
-                version_endpoint_id: destination.version_endpoint.id,
+                version_endpoint_id: destination.version_endpoint.id
               });
             });
           });
@@ -58,8 +58,11 @@ export const MerlinDeploymentsTable = ({ project, models }) => {
 
   const cellProps = item => ({
     style: { cursor: "pointer" },
-    onClick: () => window.location.href = `/merlin/projects/${project.id}/models/${item.id}/versions/${item.version_id}/endpoints/${item.version_endpoint_id}/details`,
+    onClick: () =>
+      (window.location.href = `/merlin/projects/${project.id}/models/${item.id}/versions/${item.version_id}/endpoints/${item.version_endpoint_id}/details`)
   });
 
-  return <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />;
+  return (
+    <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />
+  );
 };

--- a/ui/packages/app/src/pages/project/components/ProjectSummary.js
+++ b/ui/packages/app/src/pages/project/components/ProjectSummary.js
@@ -1,9 +1,5 @@
 import React from "react";
-import {
-  EuiIcon,
-  EuiLink,
-  EuiText
-} from "@elastic/eui";
+import { EuiIcon, EuiLink, EuiText } from "@elastic/eui";
 // import { CollapsibleLabelsPanel } from "@gojek/mlp-ui";
 import { Panel } from "./Panel";
 
@@ -30,14 +26,23 @@ export const ProjectSummary = ({ project, environments }) => {
     {
       title: "Modified at",
       description: moment(project.updated_at).format("DD-MM-YYYY")
-    },
+    }
   ];
 
   const actions = (
     <EuiLink href={`/projects/${project.id}/settings`}>
-      <EuiText size="s"><EuiIcon type="arrowRight" /> Go to Project Settings</EuiText>
+      <EuiText size="s">
+        <EuiIcon type="arrowRight" /> Go to Project Settings
+      </EuiText>
     </EuiLink>
   );
 
-  return <Panel title="Project Info" items={items} actions={actions} iconType="machineLearningApp" />;
+  return (
+    <Panel
+      title="Project Info"
+      items={items}
+      actions={actions}
+      iconType="machineLearningApp"
+    />
+  );
 };

--- a/ui/packages/app/src/pages/project/components/Resources.js
+++ b/ui/packages/app/src/pages/project/components/Resources.js
@@ -49,7 +49,10 @@ export const Resources = ({
       size="s">
       Create FeatureTable
     </EuiContextMenuItem>,
-    <EuiContextMenuItem href={`${config.MERLIN_UI_HOMEPAGE}/projects/${project.id}`} key="model" size="s">
+    <EuiContextMenuItem
+      href={`${config.MERLIN_UI_HOMEPAGE}/projects/${project.id}`}
+      key="model"
+      size="s">
       Deploy model
     </EuiContextMenuItem>,
     <EuiContextMenuItem
@@ -95,14 +98,16 @@ export const Resources = ({
           Clockwork Pipelines
         </EuiLink>
       )
-    },
+    }
   ];
 
   const actions = (
     <EuiPopover
       button={
         <EuiLink onClick={onButtonClick}>
-          <EuiText size="s"><EuiIcon type="arrowRight" /> Create a new resource</EuiText>
+          <EuiText size="s">
+            <EuiIcon type="arrowRight" /> Create a new resource
+          </EuiText>
         </EuiLink>
       }
       isOpen={isPopoverOpen}
@@ -114,5 +119,12 @@ export const Resources = ({
     </EuiPopover>
   );
 
-  return <Panel title="Resources" items={items} actions={actions} iconType="beaker" />;
+  return (
+    <Panel
+      title="Resources"
+      items={items}
+      actions={actions}
+      iconType="beaker"
+    />
+  );
 };

--- a/ui/packages/app/src/pages/project/components/TuringRoutersTable.js
+++ b/ui/packages/app/src/pages/project/components/TuringRoutersTable.js
@@ -47,8 +47,11 @@ export const TuringRoutersTable = ({ project, routers }) => {
 
   const cellProps = item => ({
     style: { cursor: "pointer" },
-    onClick: () => window.location.href = `/turing/projects/${project.id}/routers/${item.id}/details`,
+    onClick: () =>
+      (window.location.href = `/turing/projects/${project.id}/routers/${item.id}/details`)
   });
 
-  return <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />;
+  return (
+    <EuiInMemoryTable items={items} columns={columns} cellProps={cellProps} />
+  );
 };

--- a/ui/packages/app/src/services/merlin/Model.js
+++ b/ui/packages/app/src/services/merlin/Model.js
@@ -4,7 +4,7 @@ export const MODEL_TYPE_NAME_MAP = {
   sklearn: "SKLearn",
   tensorflow: "Tensorflow",
   xgboost: "XGBoost",
-  
+
   pyfunc: "Pyfunc",
   pyfunc_v2: "Pyfunc",
   custom: "Custom"

--- a/ui/packages/lib/src/components/collapsible_labels_panels/CollapsibleLabelsPanel.js
+++ b/ui/packages/lib/src/components/collapsible_labels_panels/CollapsibleLabelsPanel.js
@@ -1,9 +1,5 @@
 import React from "react";
-import {
-  EuiBadge,
-  EuiLink,
-  EuiBadgeGroup,
-} from "@elastic/eui";
+import { EuiBadge, EuiLink, EuiBadgeGroup } from "@elastic/eui";
 import EllipsisText from "react-ellipsis-text";
 import useCollapse from "react-collapsed";
 

--- a/ui/packages/lib/src/components/header/Header.js
+++ b/ui/packages/lib/src/components/header/Header.js
@@ -22,7 +22,7 @@ export const Header = ({
   userMenuItems,
   helpLink,
   docLinks,
-  homepage,
+  homepage
 }) => {
   const { state, onLogout } = useContext(AuthContext);
   const { projects } = useContext(ProjectsContext);

--- a/ui/packages/lib/src/components/multi_steps_form/StepsWizardHorizontal.js
+++ b/ui/packages/lib/src/components/multi_steps_form/StepsWizardHorizontal.js
@@ -44,7 +44,9 @@ export const StepsWizardHorizontal = ({
         <EuiSpacer size="l" />
 
         <EuiFlexItem>
-          <StepContent width={steps[currentStep].width}>{steps[currentStep].children}</StepContent>
+          <StepContent width={steps[currentStep].width}>
+            {steps[currentStep].children}
+          </StepContent>
         </EuiFlexItem>
 
         <EuiSpacer size="l" />

--- a/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
+++ b/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
@@ -59,7 +59,7 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
           children: children
         };
       }),
-    [apps, homeUrl, projectId]
+    [apps, homeUrl, projectId, isRootApplication]
   );
 
   const adminLinks = [

--- a/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
+++ b/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
@@ -9,25 +9,56 @@ import {
   EuiHeaderSectionItemButton,
   EuiIcon,
   EuiFlexItem,
-  EuiSpacer
+  EuiSpacer,
+  EuiTreeView
 } from "@elastic/eui";
 import ApplicationsContext from "../../providers/application/context";
 import { CurrentProjectContext } from "../../providers/project";
-import { useToggle } from "../../hooks/useToggle";
+import { useToggle } from "../../hooks";
+import { navigate } from "@reach/router";
+import { get, slugify } from "../../utils";
+import urlJoin from "proper-url-join";
+
 import "./NavDrawer.scss";
 
 export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
   const { projectId } = useContext(CurrentProjectContext);
   const { apps } = useContext(ApplicationsContext);
 
+  const isRootApplication = homeUrl === "/";
+
   const mlpLinks = useMemo(
     () =>
-      apps.map(a => ({
-        label: a.name,
-        iconType: a.icon,
-        href: projectId ? `${a.href}/projects/${projectId}` : a.href,
-        isActive: a.href === homeUrl
-      })),
+      apps.map(a => {
+        const isAppActive = a.href === homeUrl;
+
+        const children =
+          !!projectId && get(a, "config.sections")
+            ? a.config.sections.map(s => ({
+                id: slugify(`${a.name}.${s.name}`),
+                label: s.name,
+                callback: () =>
+                  navigate(urlJoin(a.href, "projects", projectId, s.href)),
+                className: "euiTreeView__node---small---subsection"
+              }))
+            : undefined;
+
+        return {
+          id: slugify(a.name),
+          label: a.name,
+          icon: <EuiIcon type={a.icon} />,
+          isExpanded: isAppActive || isRootApplication,
+          className: isAppActive
+            ? "euiTreeView__node---small---active"
+            : "euiTreeView__node---small",
+
+          callback: () =>
+            !children || !projectId
+              ? navigate(projectId ? `${a.href}/projects/${projectId}` : a.href)
+              : {},
+          children: children
+        };
+      }),
     [apps, homeUrl, projectId]
   );
 
@@ -39,8 +70,12 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
     }
   ];
 
-  const [navIsOpen, setNavIsOpen] = useState(JSON.parse(String(localStorage.getItem('mlp-navIsDocked'))) || false);
-  const [navIsDocked, setNavIsDocked] = useState(JSON.parse(String(localStorage.getItem('mlp-navIsDocked'))) || false);
+  const [navIsOpen, setNavIsOpen] = useState(
+    JSON.parse(String(localStorage.getItem("mlp-navIsDocked"))) || false
+  );
+  const [navIsDocked, setNavIsDocked] = useState(
+    JSON.parse(String(localStorage.getItem("mlp-navIsDocked"))) || false
+  );
 
   const [appExpanded, toggleAppExpanded] = useToggle(true);
   const [docsExpanded, toggleDocsExpanded] = useToggle(true);
@@ -72,13 +107,10 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
               onToggle={toggleAppExpanded}
               iconType="apps"
               title="Products">
-              <EuiListGroup
+              <EuiTreeView
                 aria-label="MLP apps"
-                listItems={mlpLinks}
-                maxWidth="none"
-                color="text"
-                gutterSize="s"
-                size="s"
+                items={mlpLinks}
+                className="mlpApplications"
               />
             </EuiCollapsibleNavGroup>
           )}
@@ -127,7 +159,7 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
               onClick={() => {
                 setNavIsDocked(!navIsDocked);
                 localStorage.setItem(
-                  'mlp-navIsDocked',
+                  "mlp-navIsDocked",
                   JSON.stringify(!navIsDocked)
                 );
               }}

--- a/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
+++ b/ui/packages/lib/src/components/nav_drawer/NavDrawer.js
@@ -25,42 +25,40 @@ export const NavDrawer = ({ homeUrl = "/", docLinks }) => {
   const { projectId } = useContext(CurrentProjectContext);
   const { apps } = useContext(ApplicationsContext);
 
-  const isRootApplication = homeUrl === "/";
+  const mlpLinks = useMemo(() => {
+    const isRootApplication = homeUrl === "/";
 
-  const mlpLinks = useMemo(
-    () =>
-      apps.map(a => {
-        const isAppActive = a.href === homeUrl;
+    return apps.map(a => {
+      const isAppActive = a.href === homeUrl;
 
-        const children =
-          !!projectId && get(a, "config.sections")
-            ? a.config.sections.map(s => ({
-                id: slugify(`${a.name}.${s.name}`),
-                label: s.name,
-                callback: () =>
-                  navigate(urlJoin(a.href, "projects", projectId, s.href)),
-                className: "euiTreeView__node---small---subsection"
-              }))
-            : undefined;
+      const children =
+        !!projectId && get(a, "config.sections")
+          ? a.config.sections.map(s => ({
+              id: slugify(`${a.name}.${s.name}`),
+              label: s.name,
+              callback: () =>
+                navigate(urlJoin(a.href, "projects", projectId, s.href)),
+              className: "euiTreeView__node---small---subsection"
+            }))
+          : undefined;
 
-        return {
-          id: slugify(a.name),
-          label: a.name,
-          icon: <EuiIcon type={a.icon} />,
-          isExpanded: isAppActive || isRootApplication,
-          className: isAppActive
-            ? "euiTreeView__node---small---active"
-            : "euiTreeView__node---small",
+      return {
+        id: slugify(a.name),
+        label: a.name,
+        icon: <EuiIcon type={a.icon} />,
+        isExpanded: isAppActive || isRootApplication,
+        className: isAppActive
+          ? "euiTreeView__node---small---active"
+          : "euiTreeView__node---small",
 
-          callback: () =>
-            !children || !projectId
-              ? navigate(projectId ? `${a.href}/projects/${projectId}` : a.href)
-              : {},
-          children: children
-        };
-      }),
-    [apps, homeUrl, projectId, isRootApplication]
-  );
+        callback: () =>
+          !children || !projectId
+            ? navigate(projectId ? `${a.href}/projects/${projectId}` : a.href)
+            : {},
+        children: children
+      };
+    });
+  }, [apps, homeUrl, projectId]);
 
   const adminLinks = [
     {

--- a/ui/packages/lib/src/components/nav_drawer/NavDrawer.scss
+++ b/ui/packages/lib/src/components/nav_drawer/NavDrawer.scss
@@ -1,3 +1,5 @@
+@import "~@elastic/eui/src/global_styling/variables/index";
+
 .euiBody--collapsibleNavIsDocked {
   transition: none !important;
 }
@@ -8,5 +10,32 @@
   width: 262px !important;
 
   -webkit-animation: none !important;
-  animation        : none !important;
+  animation: none !important;
+}
+
+.euiTreeView.mlpApplications {
+  padding: 0 8px;
+
+  .euiTreeView__nodeInner:focus {
+    animation: none !important;
+  }
+
+  .euiTreeView__node---small {
+    font-size: $euiFontSizeS;
+    color: $euiTextColor;
+    font-weight: $euiFontWeightMedium;
+    letter-spacing: 0;
+    padding: 4px 8px;
+  }
+
+  .euiTreeView__node---small---active {
+    @extend .euiTreeView__node---small;
+    background-color: #e6f0f8;
+  }
+
+  .euiTreeView__node---small---subsection {
+    @extend .euiTreeView__node---small;
+    color: $euiTextSubduedColor;
+    padding-left: 16px !important;
+  }
 }


### PR DESCRIPTION
### Context:
MLP's functionality is expanding and with that, a single flat-level navigation that we have in a collapsible nav-bar is no longer sufficient. This PR updates Applications API to store/serve extra application configuration (currently, only nested sections in the navigation menu) and updates `ui/packages/lib/NavDrawer` with `EuiTreeView` to support more complex navigation within a specific MLP application.

### Demo:
<img width="262" alt="Screenshot 2021-07-30 at 16 30 01" src="https://user-images.githubusercontent.com/1886194/127661114-18eec002-a187-4720-b370-96882b35c548.png">
