### PR TITLE
[BUG] Fix helm chart to support double-quotes in the db-migration files

### DIFF
--- a/chart/templates/configmap-db-migrations.yaml
+++ b/chart/templates/configmap-db-migrations.yaml
@@ -5,5 +5,6 @@ metadata:
 data:
   {{- $root := . }}
   {{ range $path, $_ := .Files.Glob "db-migrations/*.sql" }}
-  {{ base $path }}: "{{ $root.Files.Get $path }}"
+{{ base $path | indent 2  }}: |-
+{{ $root.Files.Get $path | indent 4}}
   {{- end }}


### PR DESCRIPTION
In the current deployment schema, DB migrations files are stored as a ConfigMap. The way how the relevant part is defined in the helm chart makes it impossible to have double-quotes (`"`) characters in the migration file content, because it breaks the template formatting. This PR is to fix it.