### PR TITLE
Expose counter metric collector in interface

### DIFF
--- a/api/pkg/instrumentation/metrics/metrics.go
+++ b/api/pkg/instrumentation/metrics/metrics.go
@@ -22,6 +22,7 @@ type Collector interface {
 	// at the time of logging
 	MeasureDurationMs(key MetricName, labels map[string]func() string) func()
 	RecordGauge(key MetricName, value float64, labels map[string]string) error
+	Inc(key MetricName, labels map[string]string) error
 }
 
 // globalMetricsCollector is initialised to a Nop metrics collector. Calling

--- a/api/pkg/instrumentation/metrics/prometheus.go
+++ b/api/pkg/instrumentation/metrics/prometheus.go
@@ -90,16 +90,17 @@ func InitPrometheusMetricsCollector(
 	return nil
 }
 
-func (p PrometheusClient) Inc(key MetricName, labels map[string]string) {
+func (p PrometheusClient) Inc(key MetricName, labels map[string]string) error {
 	counterVec, err := getCounterVec(key, p.counterMap)
 	if err != nil {
-		return
+		return err
 	}
 	counter, err := counterVec.GetMetricWith(labels)
 	if err != nil {
-		return
+		return err
 	}
 	counter.Inc()
+	return nil
 }
 
 // MeasureDurationMsSince takes in the Metric name, the start time and a map of labels and values


### PR DESCRIPTION
Counter metric support is implemented in https://github.com/gojek/mlp/pull/34 but not exposed to the user via Collector interface.