### PR TITLE
Add Experiments section to Turing app config

### DIFF
--- a/db-migrations/8_update_turing_app_config.down.sql
+++ b/db-migrations/8_update_turing_app_config.down.sql
@@ -1,0 +1,3 @@
+UPDATE applications
+SET config = '{"sections": [{"name": "Routers", "href": "/routers"}, {"name": "Ensemblers", "href": "/ensemblers"}, {"name": "Ensembling Jobs", "href": "/jobs"}]}'
+WHERE name = 'Turing';

--- a/db-migrations/8_update_turing_app_config.up.sql
+++ b/db-migrations/8_update_turing_app_config.up.sql
@@ -1,0 +1,21 @@
+UPDATE applications
+SET config = '{
+    "sections": [
+        {
+            "name": "Routers",
+            "href": "/routers"
+        },
+        {
+            "name": "Ensemblers",
+            "href": "/ensemblers"
+        },
+        {
+            "name": "Ensembling Jobs",
+            "href": "/jobs"
+        },
+        {
+            "name": "Experiments",
+            "href": "/experiments"
+        }
+    ]
+}' WHERE name = 'Turing';


### PR DESCRIPTION
This MR adds the `Experiments` section to the Turing app under which path (ref: [/experiments](https://github.com/gojek/turing/blob/main/ui/src/App.js#L64)) the UI for the [Default Experiment Engine](https://github.com/gojek/turing/blob/main/ui/.env#L31) used by Turing would be made available.