### PR TITLE
Publish MLP charts to turing-ml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,20 @@ jobs:
       run: ./scripts/e2e/deploy-mlp.sh "charts/mlp"
     - name: Run E2E test
       run: ./scripts/e2e/run-e2e.sh "api"
+
+  release-charts:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    needs: e2e-test
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run chart-releaser
+        uses: stefanprodan/helm-gh-pages@v1.4.1
+        with:
+          token: "${{ secrets.GH_PAGES_TOKEN }}"
+          charts_url: https://turing-ml.github.io/charts
+          charts_dir: charts
+          owner: turing-ml
+          repository: charts
+          commit_username: ${{ github.actor }}
+          commit_email: "${{ github.actor }}@users.noreply.github.com"

--- a/charts/mlp/requirements.lock
+++ b/charts/mlp/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable
   version: 7.0.0
-digest: sha256:febd879a2a7c90c31d599e6a0d20230ae1559946f7620437d6843fcaa2f75ec0
-generated: "2020-09-29T19:36:30.716064+07:00"
+digest: sha256:ebabf87f4d5c0cde325c61a4d930b91b0b1162f8cb5d3e7dbabfa02b922dac86
+generated: "2021-10-28T16:43:49.713562+08:00"

--- a/charts/mlp/requirements.yaml
+++ b/charts/mlp/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: postgresql
-    repository: "@stable"
+    repository: https://charts.helm.sh/stable
     version: 7.0.0


### PR DESCRIPTION
I have tested the push to the chart repository as can be seen here: https://github.com/turing-ml/charts

I have set it to only release on tags.

Also, I have updated the stable repository to the new stable repository to get things working.