### PR TITLE
Sync versions to follow tagged version

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "MLP API"
 name: mlp
-version: 1.0.0
+version: 1.4.17


### PR DESCRIPTION
I just realised that we are using a tagged version that is out of sync with the chart version. This will release along side with the actual chart version.