### PR TITLE
Allow external databases to be used instead of the Kubernetes PostgreSQL chart.

### DIFF
--- a/charts/mlp/Chart.yaml
+++ b/charts/mlp/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: "MLP API"
 name: mlp
-version: 1.0.0
+version: 1.0.1

--- a/charts/mlp/requirements.yaml
+++ b/charts/mlp/requirements.yaml
@@ -2,3 +2,4 @@ dependencies:
   - name: postgresql
     repository: https://charts.helm.sh/stable
     version: 7.0.0
+    condition: postgresql.enabled

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -25,17 +25,17 @@
 {{- end -}}
 
 {{- define "postgres.username" -}}
-{{- if .Values.externalPostgres.enabled -}}
-{{- .Values.externalPostgres.username -}}
-{{- else -}}
+{{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.postgresqlUsername -}}
+{{- else -}}
+{{- .Values.externalPostgres.username -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "postgres.database" -}}
-{{- if .Values.externalPostgres.enabled -}}
-{{- .Values.externalPostgres.database -}}
-{{- else -}}
+{{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.postgresqlDatabase -}}
+{{- else -}}
+{{- .Values.externalPostgres.database -}}
 {{- end -}}
 {{- end -}}

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -28,7 +28,7 @@
 {{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.postgresqlUsername -}}
 {{- else -}}
-{{- .Values.externalPostgres.username -}}
+{{- .Values.externalPostgresql.username -}}
 {{- end -}}
 {{- end -}}
 
@@ -36,6 +36,6 @@
 {{- if .Values.postgresql.enabled -}}
 {{- .Values.postgresql.postgresqlDatabase -}}
 {{- else -}}
-{{- .Values.externalPostgres.database -}}
+{{- .Values.externalPostgresql.database -}}
 {{- end -}}
 {{- end -}}

--- a/charts/mlp/templates/_helpers.tpl
+++ b/charts/mlp/templates/_helpers.tpl
@@ -1,3 +1,4 @@
+{{/* vim: set filetype=mustache: */}}
 {{- define "mlp.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -19,6 +20,22 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "postgresql.host" -}}
+{{- define "postgres.host" -}}
 {{- printf "%s-postgresql.%s.svc.cluster.local" .Release.Name .Release.Namespace -}}
+{{- end -}}
+
+{{- define "postgres.username" -}}
+{{- if .Values.externalPostgres.enabled -}}
+{{- .Values.externalPostgres.username -}}
+{{- else -}}
+{{- .Values.postgresql.postgresqlUsername -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgres.database" -}}
+{{- if .Values.externalPostgres.enabled -}}
+{{- .Values.externalPostgres.database -}}
+{{- else -}}
+{{- .Values.postgresql.postgresqlDatabase -}}
+{{- end -}}
 {{- end -}}

--- a/charts/mlp/templates/deployment.yaml
+++ b/charts/mlp/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
           - |
             /migrate \
             -path /migrations \
-            -database postgres://{{ .Values.postgresql.postgresqlUsername }}:$(PG_PASSWORD)@{{ template "postgresql.host" . }}:5432/{{ .Values.postgresql.postgresqlDatabase }}?sslmode=disable \
+            -database postgres://{{ template "postgres.username" . }}:$(PG_PASSWORD)@{{ template "postgres.host" . }}:5432/{{ template "postgres.database" . }}?sslmode=disable \
             up
         env:
           - name: PG_PASSWORD
@@ -87,16 +87,16 @@ spec:
             - name: PORT
               value: "{{ .Values.mlp.service.internalPort }}"
             - name: DATABASE_HOST
-              value: {{ template "postgresql.host" . }}
+              value: {{ template "postgres.host" . }}
             - name: DATABASE_USER
-              value: "{{ .Values.postgresql.postgresqlUsername }}"
+              value: {{ template "postgres.username" . }}
             - name: DATABASE_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Release.Name }}-postgresql
                   key: postgresql-password
             - name: DATABASE_NAME
-              value: "{{ .Values.postgresql.postgresqlDatabase }}"
+              value: {{ template "postgres.database" . }}
             - name: GITLAB_ENABLED
               value: "{{ .Values.gitlab.enabled }}"
             {{- if .Values.gitlab.enabled }}

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.externalPostgres.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "mlp.name" . }}
+    chart: {{ include "mlp.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+stringData:
+  postgresql-password: {{ .Values.externalPostgres.password }}
+{{- end -}}

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -11,5 +11,5 @@ metadata:
     heritage: {{ .Release.Service }}
 type: Opaque
 stringData:
-  postgresql-password: {{ .Values.externalPostgres.password }}
+  postgresql-password: {{ .Values.externalPostgresql.password }}
 {{- end -}}

--- a/charts/mlp/templates/postgres-secret.yaml
+++ b/charts/mlp/templates/postgres-secret.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalPostgres.enabled }}
+{{- if not .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/mlp/templates/postgres-service.yaml
+++ b/charts/mlp/templates/postgres-service.yaml
@@ -11,5 +11,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   type: ExternalName
-  externalName: {{ .Values.externalPostgres.address }}
+  externalName: {{ .Values.externalPostgresql.address }}
 {{- end -}}

--- a/charts/mlp/templates/postgres-service.yaml
+++ b/charts/mlp/templates/postgres-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.externalPostgres.enabled }}
+{{- if not .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/mlp/templates/postgres-service.yaml
+++ b/charts/mlp/templates/postgres-service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.externalPostgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "mlp.name" .}}
+    chart: {{ template "mlp.chart" .}}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  name: {{ template "mlp.fullname" .}}-postgresql
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: ExternalName
+  externalName: {{ .Values.externalPostgres.address }}
+{{- end -}}

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -79,7 +79,6 @@ gitlab:
 
 # If you would like to use an external postgres database, you can connect using these credentials
 externalPostgres:
-  enabled: false
   username: mlp
   database: mlp
   password: password

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -78,7 +78,7 @@ gitlab:
   clientSecret: #clientSecret
 
 # If you would like to use an external postgres database, you can connect using these credentials
-externalPostgres:
+externalPostgresql:
   username: mlp
   database: mlp
   password: password

--- a/charts/mlp/values.yaml
+++ b/charts/mlp/values.yaml
@@ -3,7 +3,7 @@ mlp:
     pullPolicy: IfNotPresent
     registry: ghcr.io
     repository: gojek/mlp
-    tag: 0.1.0
+    tag: v1.5.0
   replicaCount: 1
 
   ## Configure resource requests and limits
@@ -27,7 +27,7 @@ mlp:
   environment: "production"
   encryption:
     # encryption.key must be specified using --set flag.
-    key: ""
+    key: "example-key-here"
   authorization:
     enabled: false
     serverUrl: http://mlp-authorization-keto
@@ -77,7 +77,16 @@ gitlab:
   clientId: #clientId
   clientSecret: #clientSecret
 
+# If you would like to use an external postgres database, you can connect using these credentials
+externalPostgres:
+  enabled: false
+  username: mlp
+  database: mlp
+  password: password
+  address: 127.0.0.1
+
 postgresql:
+  enabled: true
   ## Configure resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##


### PR DESCRIPTION
This PR is to allow external PostgreSQL instances to be used instead of the PostgreSQL that is deployed into Kubernetes. The main motivation is for us to use PostgreSQL that is provided by our cloud platform. This is completely backward compatible.

To enable this feature, postgresql.enabled should be set to false and the object in externalPostgres should be set, including externalPostgres.enabled to be set to true.