### PR TITLE
Increase performance of listing projects by making Ory calls concurrent.

### DIFF
--- a/api/pkg/authz/enforcer/enforcer.go
+++ b/api/pkg/authz/enforcer/enforcer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -162,6 +163,7 @@ func (e *enforcer) FilterAuthorizedResource(user string, resources []string, act
 	for _, item := range allowedResourcesConcurrent.GetItems() {
 		allowedResources = append(allowedResources, item.(string))
 	}
+	sort.Strings(allowedResources)
 	return allowedResources, nil
 }
 

--- a/api/pkg/authz/enforcer/enforcer_test.go
+++ b/api/pkg/authz/enforcer/enforcer_test.go
@@ -2,7 +2,6 @@ package enforcer
 
 import (
 	"os"
-	"sort"
 	"testing"
 	"time"
 
@@ -185,8 +184,6 @@ func TestEnforcer_FilterAuthorizedResource(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := enforcer.FilterAuthorizedResource(tt.user, tt.resources, tt.action)
 			assert.NoError(t, err)
-			sort.Strings(tt.expectedResources)
-			sort.Strings(res)
 			assert.Equal(t, tt.expectedResources, res)
 		})
 	}

--- a/api/pkg/authz/enforcer/enforcer_test.go
+++ b/api/pkg/authz/enforcer/enforcer_test.go
@@ -2,6 +2,7 @@ package enforcer
 
 import (
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -184,6 +185,8 @@ func TestEnforcer_FilterAuthorizedResource(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			res, err := enforcer.FilterAuthorizedResource(tt.user, tt.resources, tt.action)
 			assert.NoError(t, err)
+			sort.Strings(tt.expectedResources)
+			sort.Strings(res)
 			assert.Equal(t, tt.expectedResources, res)
 		})
 	}

--- a/api/util/concurrent.go
+++ b/api/util/concurrent.go
@@ -1,0 +1,22 @@
+package util
+
+import "sync"
+
+// ConcurrentSlice is a slice that can be appended concurrently
+type ConcurrentSlice struct {
+	sync.RWMutex
+	items []interface{}
+}
+
+// Append safely appends items to a slice
+func (cs *ConcurrentSlice) Append(item interface{}) {
+	cs.Lock()
+	defer cs.Unlock()
+
+	cs.items = append(cs.items, item)
+}
+
+// GetItems gets the items from the list, should only be used when there are no operations working on it.
+func (cs *ConcurrentSlice) GetItems() []interface{} {
+	return cs.items
+}


### PR DESCRIPTION
With 120+ projects in place, as an administrator, it takes more than 5 seconds to list all the projects (/v1/projects) endpoint. Since it makes a lot of sequential calls to Ory, I have made it asynchronous in order to cut the loading time to under 1 second.