### PR TITLE
Remove MLP logo's reach router link navigation to force page reload

### DIFF
--- a/ui/packages/lib/src/components/header/Header.js
+++ b/ui/packages/lib/src/components/header/Header.js
@@ -15,7 +15,6 @@ import { HeaderUserMenu } from "./HeaderUserMenu";
 import { slugify } from "../../utils";
 import { NavDrawer } from "../nav_drawer";
 import "./Header.scss";
-import { Link } from "@reach/router";
 
 export const Header = ({
   homeUrl = "/",
@@ -36,11 +35,11 @@ export const Header = ({
         </EuiHeaderSectionItem>
 
         <EuiHeaderSectionItem border="right">
-          <Link to={homepage ? homepage : "/"}>
+          <a href={homepage ? homepage : "/"}>
             <EuiText className="header-title">
               <h4>Machine Learning Platform</h4>
             </EuiText>
-          </Link>
+          </a>
         </EuiHeaderSectionItem>
         <ProjectsDropdown
           projects={projects}


### PR DESCRIPTION
## Context
Although the MLP UI is used as part of the UI of the various MLP products (Turing, Merlin, Feast), these individual applications have their UI **_deployed independently as separate single page applications_**. Each of these applications also uses common MLP components such as the `Header` found at the top of their UI.

In PR #22, a change was made to ensure that a user clicking on the MLP logo (see image below) when browsing **_any_** of the single page applications, would be redirected to the MLP project landing page (which displays a summary of all deployments across the various MLP products) corresponding to the currently selected project id. 

![Screenshot 2022-08-04 at 2 49 44 PM](https://user-images.githubusercontent.com/36802364/182782283-8cc65952-5369-44fd-9843-9063b601028a.png)

This occurs by first loading the MLP homepage (with the `/` endpoint), which then gets redirected to the MLP project landing page by retrieving the state of the selected project id.

![Screenshot 2022-08-04 at 3 42 05 PM](https://user-images.githubusercontent.com/36802364/182792061-44947ceb-0d07-494d-9616-453a928fd48a.png)

However in PR #32, a separate modification to the `Header` component has been made such that clicking on the same button when browsing any of the single page applications would instead cause the user to be navigated to the corresponding landing pages of the single page applications (i.e. the pages with the endpoints `.../[mlp_app_name]/`).

![Screenshot 2022-08-04 at 3 43 29 PM](https://user-images.githubusercontent.com/36802364/182792356-41438452-c383-470f-8e37-e38bfdb15c7b.png)

This is due to the [replacement](https://github.com/gojek/mlp/pull/32/files) of the href anchor tag in `ui/packages/lib/src/components/header/Header.js` with the `Link` component of `@reach/router`, which redirect users to the individual landing pages instead of the MLP homepage. 

```js
          <Link to={homepage ? homepage : "/"}>
            <EuiText className="header-title">
              <h4>Machine Learning Platform</h4>
            </EuiText>
          </Link>
```

More concretely, the href anchor tag forced an entire page reload, which brought users back to the MLP homepage whereas the `Link` component was simply causing react components for the individual `.../[mlp_app_name]/` endpoints to be reloaded, hence bringing users back to the individual landing pages.

## Problem 
Given that each of the UI of these applications are independent (and can each use different versions of `mlp-ui` as dependencies), when they are integrated together, it has been observed that the MLP logo redirects users inconsistently across the various apps; Turing UI redirects users to its landing page whereas Merlin and Feast UI redirects users to the MLP homepage. This is entirely normal and expected given that each UI are separate and use different versions of `mlp-ui`.

However, given the need to align these differences and to provide a uniform user experience, it has been agreed that the MLP logo should redirect users back to the MLP project landing page. 

Thus, this PR simply aims to revert the change made in PR #32 to force a page reload when the MLP logo is clicked.

cc @romanwozniak 

## Modifications
- `ui/packages/lib/src/components/header/Header.js` - Replacement of `Link` component with href anchor tag