### PR TITLE
Update auth/login components to use @react-oauth/google with Google Identity Services

### DIFF
--- a/ui/packages/app/src/hooks/useFeastCoreApi.js
+++ b/ui/packages/app/src/hooks/useFeastCoreApi.js
@@ -19,13 +19,9 @@ export const useFeastCoreApi = (
       baseApiUrl: config.FEAST_CORE_API,
       timeout: config.TIMEOUT,
       useMockData: config.USE_MOCK_DATA,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${authCtx.state.idToken}`
-      },
       ...options
     },
-    undefined,
+    authCtx,
     result,
     callImmediately
   );

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -30,8 +30,10 @@
     "preunlink": "yarn unlink:react && yarn unlink:react-dom"
   },
   "dependencies": {
+    "@react-oauth/google": "0.2.6",
     "classnames": "^2.2.6",
     "json-bigint": "1.0.0",
+    "jwt-decode": "^3.1.2",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "proper-url-join": "2.1.1",
@@ -39,7 +41,6 @@
     "react-collapsed": "^3.0.1",
     "react-ellipsis-text": "^1.2.1",
     "react-fast-compare": "^3.2.0",
-    "react-google-login": "5.2.2",
     "react-scroll": "^1.8.1",
     "react-sticky": "^6.0.3",
     "resize-observer-polyfill": "^1.5.1",

--- a/ui/packages/lib/src/components/Login.js
+++ b/ui/packages/lib/src/components/Login.js
@@ -7,7 +7,7 @@ import {
   EuiFlexItem,
   EuiEmptyPrompt
 } from "@elastic/eui";
-import { GoogleLogin } from "react-google-login";
+import { GoogleLogin } from "@react-oauth/google";
 import { Redirect } from "@reach/router";
 import { get } from "../utils";
 import AuthContext from "../auth/context";
@@ -15,12 +15,11 @@ import AuthContext from "../auth/context";
 export const Login = ({ location }) => {
   const {
     state: { isAuthenticated },
-    clientId,
     onLogin
   } = useContext(AuthContext);
 
-  const onFailure = response => {
-    console.log(response);
+  const onFailure = () => {
+    console.log("Login Failed");
   };
 
   return isAuthenticated ? (
@@ -40,12 +39,7 @@ export const Login = ({ location }) => {
           />
           <EuiFlexGroup direction="column" alignItems="center">
             <EuiFlexItem grow={false} style={{ maxWidth: "200px" }}>
-              <GoogleLogin
-                clientId={clientId}
-                buttonText="Login with Google"
-                onSuccess={onLogin}
-                onFailure={onFailure}
-              />
+              <GoogleLogin onSuccess={onLogin} onError={onFailure} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiPageContent>

--- a/ui/packages/lib/src/components/header/HeaderUserMenu.js
+++ b/ui/packages/lib/src/components/header/HeaderUserMenu.js
@@ -29,7 +29,7 @@ export const HeaderUserMenu = ({ profileObj, logout, children }) => {
       aria-label="Account menu"
       onClick={togglePopover}>
       <EuiAvatar
-        imageUrl={profileObj.imageUrl}
+        imageUrl={profileObj.picture}
         name={profileObj.name}
         size="s"
       />
@@ -61,7 +61,7 @@ export const HeaderUserMenu = ({ profileObj, logout, children }) => {
           responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiAvatar
-              imageUrl={profileObj.imageUrl}
+              imageUrl={profileObj.picture}
               name={profileObj.name}
               size="xl"
             />
@@ -104,7 +104,8 @@ export const HeaderUserMenu = ({ profileObj, logout, children }) => {
 HeaderUserMenu.propTypes = {
   profileObj: PropTypes.shape({
     email: PropTypes.string,
-    name: PropTypes.string
+    name: PropTypes.string,
+    picture: PropTypes.string
   }).isRequired,
   logout: PropTypes.func.isRequired
 };

--- a/ui/packages/lib/src/utils/fetchJson.js
+++ b/ui/packages/lib/src/utils/fetchJson.js
@@ -39,7 +39,7 @@ const fetchData = async (url, authCtx, options) => {
   if (typeof authCtx !== "undefined") {
     optionsWithAuth.headers = {
       ...options.headers,
-      Authorization: `Bearer ${authCtx.state.accessToken}`
+      Authorization: `Bearer ${authCtx.state.jwt}`
     };
   }
   return fetchWithTimeout(url, optionsWithAuth, options.timeout).then(

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1548,6 +1548,11 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-oauth/google@0.2.6":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@react-oauth/google/-/google-0.2.6.tgz#42f7a18c62d677c77ee8e1fc2eec2ccbe50be997"
+  integrity sha512-Az6w/EL3QHSvWVbfX2WbUB15PGqM0hm86bpAoyvjw2nhDdPp9IOjpFg5HfSGJQJBydjbCFnZjI8PJskTzLOhew==
+
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.0.tgz#9cb1c5146ddd6a4968ad96f209c50c62f92f9879"
@@ -7588,6 +7593,11 @@ jsx-ast-utils@^2.2.1, jsx-ast-utils@^2.2.3:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -10417,14 +10427,6 @@ react-focus-on@^3.5.0:
     react-style-singleton "^2.1.1"
     use-callback-ref "^1.2.5"
     use-sidecar "^1.0.5"
-
-react-google-login@5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/react-google-login/-/react-google-login-5.2.2.tgz#a20b46440c6c1610175ef75baf427118ff0e9859"
-  integrity sha512-JUngfvaSMcOuV0lFff7+SzJ2qviuNMQdqlsDJkUM145xkGPVIfqWXq9Ui+2Dr6jdJWH5KYdynz9+4CzKjI5u6g==
-  dependencies:
-    "@types/react" "*"
-    prop-types "^15.6.0"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"


### PR DESCRIPTION
### Context:

This MR updates `AuthProvider` and React components depending on it to use [@react-oauth/google](https://www.npmjs.com/package/@react-oauth/google) instead of [react-google-login](https://www.npmjs.com/package/react-google-login).

`@react-oauth/google` is built with [Google Identity Services library](https://developers.google.com/identity/gsi/web) (as opposed to the [Google Sign-In platform library](https://developers.google.com/identity/sign-in/web/sign-in), used by `react-google-login`) and it helps to retrieve JWT `IdToken`, which can be used to authenticate users after the sign-in.

### Changes:
`@react-oauth/google` works as a drop-in replacement of `react-google-login`, so no changes to the flow or components look have been made. However, the new Google sign-in button now shows the name of the user, if such user already signed to the web app before:
<img width="407" alt="Screenshot 2022-08-05 at 6 02 37 PM" src="https://user-images.githubusercontent.com/1886194/183054798-a0074323-0948-4000-8feb-95961136d735.png">

