### PR TITLE
Fix UI regressions

### DIFF
--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mlp-ui",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/ui/packages/lib/src/components/Toast.js
+++ b/ui/packages/lib/src/components/Toast.js
@@ -5,6 +5,8 @@ import isEqual from "react-fast-compare";
 let addToastHandler;
 let removeAllToastsHandler;
 
+let toastId = 0;
+
 // Other components can add toasts directly
 export const addToast = toast => {
   addToastHandler(toast);
@@ -19,6 +21,8 @@ export const Toast = ({ toastLifeTimeMs = 15000 }) => {
   const [toasts, setToasts] = useState([]);
 
   const addToast = toast => {
+    // Toast id should be unique to prevent it from being cleared continuously
+    toast.id = `${toast.id}-${toastId++}`;
     !toasts.find(t => isEqual(t, toast)) && setToasts(toasts.concat(toast));
   };
 

--- a/ui/packages/lib/src/components/multi_steps_form/StepsWizardHorizontal.js
+++ b/ui/packages/lib/src/components/multi_steps_form/StepsWizardHorizontal.js
@@ -32,8 +32,12 @@ export const StepsWizardHorizontal = ({
           <EuiStepsHorizontal
             steps={steps.map((step, idx) => ({
               title: step.title,
-              isSelected: idx === currentStep,
-              isComplete: idx < currentStep,
+              status:
+                idx === currentStep
+                  ? "current"
+                  : idx < currentStep
+                  ? "complete"
+                  : "incomplete",
               onClick: () => {
                 idx < currentStep && setCurrentStep(idx);
               }


### PR DESCRIPTION
`Regressions`
1. StepWizardHorizontal not being highlighted. Known issue mentioned [here](https://github.com/caraml-dev/xp/pull/33)
2. Toasts not showing up after getting first Toast
    - dismissToast call is immediately made upon addition of a Toast to the global list
    - Likely because toast and toastToDismiss are the same because the subsequent Toast has the same `id` as the previous, instead of an unique one (https://github.com/elastic/eui/blob/main/src/components/toast/global_toast_list.tsx#L246)

`UI Screenshots`
<img width="895" alt="Screenshot 2022-09-20 at 12 15 20 PM" src="https://user-images.githubusercontent.com/25025366/191167650-fd7b70b0-1673-4279-9669-b8be4b1da858.png">
<img width="309" alt="Screenshot 2022-09-20 at 12 15 34 PM" src="https://user-images.githubusercontent.com/25025366/191167668-7daa929e-0355-469c-94e9-476c401be994.png">

