### PR TITLE
ci: Fixing e2e tests job in ci-workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         go-version: 1.16
     - name: Install dependencies
       run: |
+        npm install --global yarn
         make setup
         make init-dep
     - name: Lint source code
@@ -103,8 +104,12 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.16
-    - name: Setup cluster
-      run: kind create cluster --image=kindest/node:v1.17.11
+    - name: Set up Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: v3.8.1
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.3.0
     - name: Create mlp namespace
       run: kubectl create namespace mlp
     - name: Deploy MLP

--- a/scripts/e2e/deploy-mlp.sh
+++ b/scripts/e2e/deploy-mlp.sh
@@ -6,14 +6,16 @@ set -o pipefail
 
 CHART_PATH="$1"
 
-helm install mlp ${CHART_PATH} --namespace=mlp \
+helm repo add caraml https://caraml-dev.github.io/helm-charts/
+
+helm install mlp caraml/mlp --namespace=mlp \
     --values=${CHART_PATH}/values-e2e.yaml \
     --set mlp.image.tag=${GITHUB_REF#refs/*/} \
     --dry-run
 
-helm install mlp ${CHART_PATH} --namespace=mlp \
+helm install mlp caraml/mlp --namespace=mlp \
     --values=${CHART_PATH}/values-e2e.yaml \
-    --set mlp.image.tag=${GITHUB_REF#refs/*/} \
-    --wait --timeout=5m
+    --wait --timeout=5m \
+    --set mlp.image.tag=${GITHUB_REF#refs/*/}
 
 kubectl get all --namespace=mlp

--- a/scripts/e2e/run-e2e.sh
+++ b/scripts/e2e/run-e2e.sh
@@ -8,7 +8,10 @@ export API_PATH="$1"
 
 export MLP_API_BASEPATH="http://127.0.0.1:8080/v1"
 
-kubectl port-forward --namespace=mlp svc/mlp 8080 &
+chartVersion=$(helm search repo caraml | awk  '{if($1=="caraml/mlp")print $2}' | sed 's/\./-/g')
+echo "mlp-$chartVersion-mlp"
+
+kubectl port-forward --namespace=mlp svc/mlp-$chartVersion-mlp 8080 &
 sleep 5
 
 curl "${MLP_API_BASEPATH}/projects" -d '{"name": "e2e-test", "team": "gojek", "stream": "gojek"}'


### PR DESCRIPTION
##Motivation:
The e2e test cases job in the ci workflow is failing because of an error from the kind cluster setup

## Changes:
* Upgrade the job to use Github action for setting up kind cluster
* Use the CaraML published helm chart by adding the repo: https://caraml-dev.github.io/helm-charts/