### PR TITLE
Use default Content-Type for Feast BFF

### DIFF
--- a/ui/packages/app/package.json
+++ b/ui/packages/app/package.json
@@ -1,13 +1,13 @@
 {
   "name": "mlp-ui",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
     "@elastic/datemath": "^5.0.3",
     "@elastic/eui": "66.0.0",
     "@emotion/react": "^11.9.0",
-    "@gojek/mlp-ui": "1.6.1",
+    "@gojek/mlp-ui": "1.7.0",
     "@sentry/browser": "5.15.5",
     "moment": "^2.29.4",
     "object-assign-deep": "0.4.0",

--- a/ui/packages/app/src/hooks/useFeastCoreApi.js
+++ b/ui/packages/app/src/hooks/useFeastCoreApi.js
@@ -19,7 +19,11 @@ export const useFeastCoreApi = (
       baseApiUrl: config.FEAST_CORE_API,
       timeout: config.TIMEOUT,
       useMockData: config.USE_MOCK_DATA,
-      ...options
+      ...options,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers
+      }
     },
     authCtx,
     result,

--- a/ui/packages/lib/package.json
+++ b/ui/packages/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gojek/mlp-ui",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
# Context:

Feast BFF expects a proper `Content-Type` header to be present in the API calls. This MR sets the `"Content-Type": "application/json"` header by default at the level of the `useFeastCoreApi` hook, so that there is no need to add it to each API call separately.