### PR TITLE
Update PageNavigation to use useNavigate hook

### DIFF
--- a/ui/packages/lib/src/components/page_navigation/PageNavigation.js
+++ b/ui/packages/lib/src/components/page_navigation/PageNavigation.js
@@ -88,7 +88,6 @@ const MoreActionsButton = ({ actions }) => {
       panelPaddingSize="none"
       anchorPosition="downRight">
       <EuiContextMenuPanel
-        hasFocus={false}
         className="euiContextPanel--moreActions"
         items={items}
       />

--- a/ui/packages/lib/src/components/page_navigation/PageNavigation.js
+++ b/ui/packages/lib/src/components/page_navigation/PageNavigation.js
@@ -9,6 +9,7 @@ import {
   EuiTab,
   EuiTabs
 } from "@elastic/eui";
+import { useNavigate } from "react-router-dom";
 
 import "./PageNavigation.scss";
 
@@ -16,31 +17,33 @@ export const PageNavigation = ({
   tabs,
   actions,
   selectedTab = "",
-  ...props
-}) => (
-  <EuiFlexGroup direction="row" gutterSize="none">
-    <EuiFlexItem grow={true}>
-      <EuiTabs>
-        {tabs.map((tab, index) => (
-          <EuiTab
-            {...(tab.href
-              ? { href: tab.href, target: "_blank" }
-              : { onClick: () => props.navigate(`./${tab.id}`) })}
-            isSelected={selectedTab.startsWith(tab.id)}
-            disabled={tab.disabled}
-            key={index}>
-            {tab.name}
-          </EuiTab>
-        ))}
-      </EuiTabs>
-    </EuiFlexItem>
-    {actions && actions.length && (
-      <EuiFlexItem grow={false}>
-        <MoreActionsButton actions={actions} />
+}) => {
+  const navigate = useNavigate();
+  return (
+    <EuiFlexGroup direction="row" gutterSize="none">
+      <EuiFlexItem grow={true}>
+        <EuiTabs>
+          {tabs.map((tab, index) => (
+            <EuiTab
+              {...(tab.href
+                ? { href: tab.href, target: "_blank" }
+                : { onClick: () => navigate(`./${tab.id}`) })}
+              isSelected={selectedTab.startsWith(tab.id)}
+              disabled={tab.disabled}
+              key={index}>
+              {tab.name}
+            </EuiTab>
+          ))}
+        </EuiTabs>
       </EuiFlexItem>
-    )}
-  </EuiFlexGroup>
-);
+      {actions && actions.length && (
+        <EuiFlexItem grow={false}>
+          <MoreActionsButton actions={actions} />
+        </EuiFlexItem>
+      )}
+    </EuiFlexGroup>
+  )
+};
 
 const MoreActionsButton = ({ actions }) => {
   const [isPopoverOpen, setPopover] = useState(false);


### PR DESCRIPTION
Since the migration from `@reach/router` to `react-router-dom` in https://github.com/gojek/mlp/pull/56, this PR updates the last remaining component that's using the now invalid `props.navigate` to the `useNavigate()` hook.

Also removing the `hasFocus` property which is now no longer valid, from `EuiContextMenuPanel`.