### PR TITLE
Add method to allow PrometheusClient to register additional metrics

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -27,8 +27,8 @@ env:
   CONTAINER_REGISTRY: ghcr.io
   LOCAL_REGISTRY: registry.localhost:5000
 
-  CARAML_CHARTS_REPOSITORY: romanwozniak/helm-charts
-  CARAML_CHARTS_REF: feat-mlp-apps-configuration
+  CARAML_CHARTS_REPOSITORY: caraml-dev/helm-charts
+  CARAML_CHARTS_REF: main
 
 jobs:
   build-ui:

--- a/api/pkg/instrumentation/metrics/prometheus.go
+++ b/api/pkg/instrumentation/metrics/prometheus.go
@@ -180,3 +180,32 @@ func (p PrometheusClient) RecordGauge(
 
 	return nil
 }
+
+func (p PrometheusClient) RegisterAdditionalMetrics(
+	gaugeMap map[MetricName]PrometheusGaugeVec,
+	histogramMap map[MetricName]PrometheusHistogramVec,
+	counterMap map[MetricName]PrometheusCounterVec,
+) error {
+	for name, obs := range gaugeMap {
+		if _, ok := p.gaugeMap[name]; ok {
+			return errors.Newf("Name of metric already exists: %s", name)
+		}
+		p.gaugeMap[name] = obs
+		prometheus.MustRegister(obs)
+	}
+	for name, obs := range histogramMap {
+		if _, ok := p.histogramMap[name]; ok {
+			return errors.Newf("Name of metric already exists: %s", name)
+		}
+		p.histogramMap[name] = obs
+		prometheus.MustRegister(obs)
+	}
+	for name, obs := range counterMap {
+		if _, ok := p.counterMap[name]; ok {
+			return errors.Newf("Name of metric already exists: %s", name)
+		}
+		p.counterMap[name] = obs
+		prometheus.MustRegister(obs)
+	}
+	return nil
+}

--- a/api/pkg/instrumentation/metrics/prometheus.go
+++ b/api/pkg/instrumentation/metrics/prometheus.go
@@ -181,28 +181,28 @@ func (p PrometheusClient) RecordGauge(
 	return nil
 }
 
-func (p PrometheusClient) RegisterAdditionalMetrics(
+func (p PrometheusClient) RegisterMetrics(
 	gaugeMap map[MetricName]PrometheusGaugeVec,
 	histogramMap map[MetricName]PrometheusHistogramVec,
 	counterMap map[MetricName]PrometheusCounterVec,
 ) error {
 	for name, obs := range gaugeMap {
 		if _, ok := p.gaugeMap[name]; ok {
-			return errors.Newf("Name of metric already exists: %s", name)
+			return errors.Newf("Metric of type Gauge with name %s already exists", name)
 		}
 		p.gaugeMap[name] = obs
 		prometheus.MustRegister(obs)
 	}
 	for name, obs := range histogramMap {
 		if _, ok := p.histogramMap[name]; ok {
-			return errors.Newf("Name of metric already exists: %s", name)
+			return errors.Newf("Metric of type Histogram with name %s already exists", name)
 		}
 		p.histogramMap[name] = obs
 		prometheus.MustRegister(obs)
 	}
 	for name, obs := range counterMap {
 		if _, ok := p.counterMap[name]; ok {
-			return errors.Newf("Name of metric already exists: %s", name)
+			return errors.Newf("Metric of type Counter with name %s already exists", name)
 		}
 		p.counterMap[name] = obs
 		prometheus.MustRegister(obs)


### PR DESCRIPTION
## Context
This PR introduces an additional method to the `PrometheusClient` to allow the registration of additional metrics after the prior creation of a `PrometheusClient` object (the existing `InitPrometheusMetricsCollector` function creates a new `PrometheusClient` object and registers metrics immediately). 

This change is needed as part of a series of other changes to the allow the XP's treatment service plugin to register additional metrics on the Turing Router's `PrometheusClient` (see https://github.com/caraml-dev/turing/pull/302 and https://github.com/caraml-dev/xp/pull/54 for more information).