### PR TITLE
[mlp] add eui super select function to list registry options

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -105,7 +105,6 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: ${{ env.GO_LINT_VERSION }}
-          skip-go-installation: true
           args: --timeout 3m --verbose api/...
 
       - name: Run Integration Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   build-tags:
     - integration
-skip-dirs:
-  - api/client
 
 linters:
   enable:
@@ -19,6 +17,9 @@ linters:
     - revive
     - staticcheck
     - unused
+  exclusions:
+    paths:
+      - api/client
 
 linters-settings:
   gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,9 @@ run:
   build-tags:
     - integration
 
+exclude:
+  - api/client
+
 linters:
   enable:
     - bodyclose
@@ -17,9 +20,6 @@ linters:
     - revive
     - staticcheck
     - unused
-  exclusions:
-    paths:
-      - api/client
 
 linters-settings:
   gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,9 @@ run:
   build-tags:
     - integration
 
-exclude:
-  - api/client
+issues:
+  exclude-dirs:
+    - api/client
 
 linters:
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
 run:
   build-tags:
     - integration
-  skip-dirs:
-    - api/client
+skip-dirs:
+  - api/client
 
 linters:
   enable:

--- a/ui/packages/lib/src/components/form/docker_image_combo_box/DockerRegistryPopover.js
+++ b/ui/packages/lib/src/components/form/docker_image_combo_box/DockerRegistryPopover.js
@@ -1,40 +1,14 @@
-import React, { useState } from "react";
-import { EuiButtonEmpty, EuiContextMenu, EuiPopover } from "@elastic/eui";
-import { flattenPanelTree } from "../../../utils";
+import { EuiSuperSelect } from "@elastic/eui";
 
 export const DockerRegistryPopover = ({ value, registryOptions, onChange }) => {
-  const [isOpen, setOpen] = useState(false);
-
-  const panels = flattenPanelTree({
-    id: 0,
-    items: registryOptions.map(registry => ({
-      name: registry.inputDisplay,
-      value: registry.value,
-      icon: "logoDocker",
-      onClick: () => {
-        togglePopover();
-        onChange(registry.value);
-      }
-    }))
-  });
-
-  const togglePopover = () => setOpen(!isOpen);
 
   return (
-    <EuiPopover
-      button={
-        <EuiButtonEmpty
-          size="xs"
-          iconType="arrowDown"
-          iconSide="right"
-          onClick={togglePopover}>
-          {registryOptions.find(o => o.value === value).inputDisplay}
-        </EuiButtonEmpty>
-      }
-      isOpen={isOpen}
-      closePopover={togglePopover}
-      panelPaddingSize="s">
-      <EuiContextMenu initialPanelId={0} panels={panels} />
-    </EuiPopover>
+    <EuiSuperSelect
+      fullWidth
+      options={registryOptions}
+      valueOfSelected={value}
+      itemLayoutAlign="top"
+      onChange={onChange}
+    />
   );
 };


### PR DESCRIPTION
This is to fix a bug - the bug crashes the ui on click of registries list
The fix uses <euisuperselect /> component to fix the UI crash. The component to load the registries is loaded from pre-build package

The relevant Merlin MR - https://github.com/caraml-dev/merlin/pull/646

Change to ci files:

1. skip-go-installation: true is not needed anymore as CI expects golang to be installed, which we already have
2. support for skip-dirs is deprecated and issues.exclude-dirs is the new approach to exclude files from golang-ci